### PR TITLE
移動経路追跡を一定時間前以前の分は描画しないように変更

### DIFF
--- a/Assets/Gimicks/DisplayPosition.shader
+++ b/Assets/Gimicks/DisplayPosition.shader
@@ -3,6 +3,8 @@ Shader "Unlit/DisplayPosition"
     Properties
     {
         _MainTex ("Texture", 2D) = "black" {}
+        _CurrentTime ("Current Time", Float) = 0
+        _DrawInterval ("Draw Time Interval", Float) = 1
     }
     SubShader
     {
@@ -31,8 +33,8 @@ Shader "Unlit/DisplayPosition"
 
             sampler2D _MainTex;
             float4 _MainTex_ST;
-            float4 _UVPos;
-            float _Scale;
+            float _CurrentTime;
+            float _DrawInterval;
 
             v2f vert (appdata v)
             {
@@ -51,7 +53,8 @@ Shader "Unlit/DisplayPosition"
             {
                 float col = tex2Dlod(_MainTex, float4(i.uv, 0, 0)).r;
                 clip (col == 0 ? -1 : 0);
-                return float4(hsv2rgb(col / _Time.y, 1, 1), 1);
+                clip(col - (_CurrentTime - _DrawInterval));
+                return float4(hsv2rgb(col / _DrawInterval, 1, 1), 1);
             }
             ENDCG
         }

--- a/Assets/Gimicks/DrawPosition.asset
+++ b/Assets/Gimicks/DrawPosition.asset
@@ -44,7 +44,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 8
+      Data: 9
     - Name: 
       Entry: 7
       Data: 
@@ -492,6 +492,69 @@ MonoBehaviour:
     - Name: 
       Entry: 7
       Data: 30|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _drawTimeInterval
+    - Name: $v
+      Entry: 7
+      Data: 31|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _drawTimeInterval
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 18
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 18
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 32|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 2
+    - Name: 
+      Entry: 7
+      Data: 33|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 34|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+    - Name: tooltip
+      Entry: 1
+      Data: Draw time interval in seconds
     - Name: 
       Entry: 8
       Data: 

--- a/Assets/Gimicks/DrawPosition.cs
+++ b/Assets/Gimicks/DrawPosition.cs
@@ -22,6 +22,8 @@ public class DrawPosition : UdonSharpBehaviour
     private MeshRenderer _displayMaterial;
     [SerializeField]
     private Transform _testTransform;
+    [SerializeField, Tooltip("Draw time interval in seconds")]
+    private float _drawTimeInterval = 60f;
 
 
     private void Start()
@@ -43,5 +45,8 @@ public class DrawPosition : UdonSharpBehaviour
         _drawMaterial.material.SetVector("_UVPos", uvPosVector4);
         VRCGraphics.Blit(_renderTexture, _bufferTexture, _drawMaterial.material);
         VRCGraphics.Blit(_bufferTexture, _renderTexture);
+
+        _displayMaterial.material.SetFloat("_DrawInterval", _drawTimeInterval);
+        _displayMaterial.material.SetFloat("_CurrentTime", Time.time);
     }
 }


### PR DESCRIPTION
デフォルトでは確認しやすいように1分前までの移動経路を描画している
通過時の時間に応じて色相を固定するようにした
シーンには変更ないです